### PR TITLE
[SC-24892] Add typesafe bintray repo for sbt-mima-plugin

### DIFF
--- a/build/sbt-config/repositories
+++ b/build/sbt-config/repositories
@@ -7,5 +7,6 @@
   typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-ivy-snapshots: https://repo.scala-sbt.org/scalasbt/ivy-snapshots/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  bintray-typesafe-sbt-plugin-releases: https://dl.bintray.com/typesafe/sbt-plugins/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
   bintray-spark-packages: https://dl.bintray.com/spark-packages/maven/
   typesafe-releases: http://repo.typesafe.com/typesafe/releases/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,3 +38,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.13")
+
+resolvers += Resolver.url("typesafe sbt-plugins",
+  url("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding the `typesafe` bintray repo for `sbt-mima-plugin` since the old `sbt-mima-plugin` was removed.

## How was this patch tested?
Run the usual tests

Closes #6744 from rahulsmahadev/mimaFix.

Lead-authored-by: Rahul Mahadev <rahul.mahadev@databricks.com>
Co-authored-by: Shixiong Zhu <zsxwing@gmail.com>
Signed-off-by: Rahul Mahadev <rahul.mahadev@databricks.com>
GitOrigin-RevId: 9cbdca25128b010f488b880a9cf7f39db89f3b2c